### PR TITLE
fix(inputs/sql): respect timeout in unprepared query fallback.

### DIFF
--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -352,7 +352,7 @@ func (s *SQL) executeQuery(ctx context.Context, acc telegraf.Accumulator, q quer
 	} else {
 		// Fallback to unprepared query
 		var err error
-		rows, err = s.db.Query(q.Query)
+		rows, err = s.db.QueryContext(ctx, q.Query)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This caused goroutines to leak on every slow/hung query cycle, accumulating to 5K+ goroutines and eventually OOMKilling the pod. Replace db.Query() with db.QueryContext(ctx) so the configured timeout actually cancels the call when the DB is unresponsive.
